### PR TITLE
ci with g8Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
-sudo: false
 language: scala
 
-# These directories are cached to S3 at the end of the build
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+sudo: false
 
-jdk:
-  - oraclejdk8
+jdk: oraclejdk8
+
+scala:
+  - 2.11.11
+  - 2.12.4
 
 script:
-  ## This runs the template with the default parameters, and runs test within the templated app.
-  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
-
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+  - sbt ";set g8Properties in g8 in Test ~= { _ + (\"scala_version\" -> \"$TRAVIS_SCALA_VERSION\")}; g8Test"


### PR DESCRIPTION
> the action g8Test will apply the template in the default output directory (under target/sbt-test) and run the scripted test for that project in a forked process. You can supply the test scripted as project/giter8.test or src/test/g8/test, otherwise >test is used. This is a good sanity check for templates that are supposed to produce sbt projects.
> http://www.foundweekends.org/giter8/testing.html

----
btw please setup travis ci settings.