### PR TITLE
Update g8 template to use reladomo-scala 16.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: scala
 
 sudo: false
 
-jdk: oraclejdk8
+jdk:
+  - oraclejdk8
+  # TODO: support
+  #- oraclejdk10
 
 scala:
-  - 2.11.11
-  - 2.12.4
+  - 2.11.12
+  - 2.12.6
 
 script:
   - sbt ";set g8Properties in g8 in Test ~= { _ + (\"scala_version\" -> \"$TRAVIS_SCALA_VERSION\")}; g8Test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.6

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.9.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.11.0")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -2,13 +2,13 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.folio-sec",
-      scalaVersion := "2.12.3"
+      scalaVersion := "2.12.6"
     )),
     name := "reladomo-simple",
     libraryDependencies ++= Seq(
-      "com.folio-sec"  %% "reladomo-scala-common" % "16.5.6",
-      "com.h2database" %  "h2"                    % "1.4.196",
-      "org.scalatest"  %% "scalatest"             % "3.0.4"    % Test
+      "com.folio-sec"  %% "reladomo-scala-common" % "16.7.0",
+      "com.h2database" %  "h2"                    % "1.4.197",
+      "org.scalatest"  %% "scalatest"             % "3.0.5"    % Test
     ),
     resolvers += "sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
   )

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.6

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,4 +1,4 @@
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 resolvers += "sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC12")
-addSbtPlugin("com.folio-sec" % "sbt-reladomo-plugin" % "16.5.6")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
+addSbtPlugin("com.folio-sec" % "sbt-reladomo-plugin" % "16.7.0")


### PR DESCRIPTION
This pull request updates the g8 template to use reladomo-scala 16.7.0.

https://github.com/folio-sec/reladomo-scala/releases/tag/v16.7.0